### PR TITLE
Add markdown output format for LLM crawlers

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -43,8 +43,22 @@ enableEmoji = true
   filename = 'sitemap.xml'
   priority = 0.5
 
+[mediaTypes]
+  [mediaTypes."text/markdown"]
+    suffixes = ["md"]
+
+[outputFormats]
+  [outputFormats.Markdown]
+    mediaType = "text/markdown"
+    isPlainText = true
+    isHTML = false
+    rel = "alternate"
+    permalinkable = true
+
 [outputs]
   home = ["HTML", "RSS", "JSON"]
+  page = ["HTML", "Markdown"]
+  section = ["HTML", "Markdown"]
   #taxonomy = ["HTML"]
 
 [related]

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,0 +1,3 @@
+# {{ .Title }}
+
+{{ .RawContent -}}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,3 +1,1 @@
-# {{ .Title }}
-
 {{ .RawContent -}}

--- a/layouts/partials/extend-head.html
+++ b/layouts/partials/extend-head.html
@@ -1,3 +1,4 @@
+{{ with .OutputFormats.Get "Markdown" }}<link rel="alternate" type="text/markdown" href="{{ .Permalink }}">{{ end }}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">


### PR DESCRIPTION
Closes #99

## Summary
- Defines a `text/markdown` media type and `Markdown` output format in Hugo config
- Hugo now generates an `index.md` alongside each `index.html` for pages and sections
- Adds `<link rel="alternate" type="text/markdown">` in each page's `<head>` for discoverability
- Markdown template outputs raw page content via `.RawContent`

https://claude.ai/code/session_01B6pJW5MUxjmytS9uo7Qb8J